### PR TITLE
Disable the puma, thin and unicorn servers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rails', '~> 5.1.3'
 # Use sqlite3 as the database for Active Record
 gem 'pg'
 # Use Puma as the app server
-gem 'puma', '~> 3.0'
+# gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -29,7 +29,7 @@ gem 'rest-client'
 gem 'netease_im'
 gem 'friendly_id'
 gem 'simple_form'
-gem 'unicorn'
+# gem 'unicorn'
 gem 'rucaptcha'
 gem 'china_sms'
 gem 'plezi'
@@ -69,7 +69,7 @@ group :development do
 
   gem 'annotate'
   gem 'foreman'
-  gem 'thin'
+  # gem 'thin'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec thin start -p 3000
+web: bundle exec iodine -p 3000


### PR DESCRIPTION
Just to make sure they aren't used by mistake.

...Since Plezi requires `iodine` to be used.